### PR TITLE
Add brunnhilde utility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Scripts and templates used for born-digital transfers at the Bentley Historical 
 - HandBrake CLI: To create DIPs for video DVDs
 - bulk_extractor: To scan for PII
 - rsync: To copy files on non-Windows machines
+- Brunnhilde: To generate reports (non-Windows machines only)
 
 ## Installation
 `pip install git+https://github.com/bentley-historical-library/bhl_born_digital_utils.git`
@@ -35,6 +36,7 @@ Usage: `bhl_bd_utils.py ACCESSION_NUMBER action [options]`
 | --av_media | Separate AV media |
 | --rename_files | Rename files with invalid characters |
 | --dips | Make DIPs for audio CDs and video DVDs |
+| --brunnhilde | Run Brunnhilde |
 
 
 ### BHL Born Digital Utils Configuration
@@ -51,6 +53,7 @@ Many of born-digital transfer utilities make use of a `.bhl_bd_utils` configurat
 | handbrake_preset | Full path to a HandBrake preset JSON file |
 | ffmpeg | Full path to an installed FFmpeg executable |
 | bulk_extractor | Full path to an installed bulk_extractor executable |
+| brunnhilde | Directory where Brunnhilde reports will be stored |
 
 Some of these settings can be overriden from the command line. For example, an `-i` flag can be passed along with the path to a directory to override the configured input directory. Below are the optional arguments that can be passed to `bhl_bd_utils.py` and the configuration default that they override.
 
@@ -188,7 +191,7 @@ This utility replaces 'invalid' characters in a filename with an underscore. The
 | ACCESSION_NUMBER | The accession number |
 | --rename_files | Rename files |
 
-## make_dips.py
+## Make DIPs
 This utility makes access derivatives (DIPs) for audio CDs and video DVDs to be uploaded to the Bentley Digital Media Library. Its primary use case is to make DIPs in batch for media transferred using the RipStation, but can also be used for media transferred using the RMWs. The utility parses the bhl_inventory.csv in a given accession directory to identify all audio CDs and video DVDs that have (1) been successfully transferred and (2) do not have an existing access derivative. The utility then does the following depending on the media type:
 
 - Audio CD: Concatenates all of the individual `.wav` tracks from an audio CD into a single `[barcode].wav` file using FFmpeg. On Windows machines, the utility uses the `ffmpeg` configuration setting, corresponding to an exact path to an FFmpeg executable, and on other operating systems assumes that `ffmpeg` is available on the system path.
@@ -200,3 +203,15 @@ This utility makes access derivatives (DIPs) for audio CDs and video DVDs to be 
 | --- | --- |
 | ACCESSION_NUMBER | The accession number |
 | --dips | Make DIPs |
+
+## Run Brunnhilde
+This utility runs [Brunnhilde](https://github.com/tw4l/brunnhilde) to generate reports on the contents of a given transfer. The utility is configured to run Brunnhilde with the `-z` (decompress and scan archived files) and `-n` (skip virus scan) options. The outputs of this scan include a CSV output from Siegfried, a tree report of the transfer's directory structure, and an HTML report with aggregate statistics for the transfer including detailed information about file formats, unidentified files, last modified dates, and duplicate files. Reports will be output to the configured `brunnhilde` directory and will be copied to the transfer's `metadata\submissionDocumentation` directory once Brunnhilde has finished.
+
+This utility can only be run from a Linux or macOS machine.
+
+`bhl_bd_utils.py ACCESSION_NUMBER --brunnhilde`
+
+| Argument | Help |
+| --- | --- |
+| ACCESSION_NUMBER | The accession number |
+| --brunnhilde | Run Brunnhilde |

--- a/bhl_bd_utils.py
+++ b/bhl_bd_utils.py
@@ -16,6 +16,7 @@ from bhl_born_digital_utils.move_separations import move_separations
 from bhl_born_digital_utils.separate_av_media import separate_av_media
 from bhl_born_digital_utils.rename_files import rename_files
 from bhl_born_digital_utils.make_dips import make_dips
+from bhl_born_digital_utils.run_brunnhilde import run_brunnhilde
 
 
 def main():
@@ -60,6 +61,8 @@ def main():
     action_args.add_argument("--rename_files", action="store_true", help="Rename files with invalid characters")
 
     action_args.add_argument("--dips", action="store_true", help="Make DIPs")
+
+    action_args.add_argument("--brunnhilde", action="store_true", help="Run Brunnhilde (Linux only)")
 
     args = parser.parse_args()
 
@@ -119,6 +122,8 @@ def main():
         rename_files(accession_dir)
     if args.dips:
         make_dips(accession_dir)
+    if args.brunnhilde:
+        run_brunnhilde(accession_dir, accession_number)
 
 
 if __name__ == "__main__":

--- a/bhl_born_digital_utils/config.py
+++ b/bhl_born_digital_utils/config.py
@@ -65,11 +65,19 @@ def _create_config(config, config_file):
         print("bulk_extractor is used to scan for PII")
         be_path_input = input("Enter the path to the bulk_extractor.exe for Windows machines: ")
         be_path = _normalize_input(be_path_input)
+
+        brunnhilde_dir = ""
     else:
         # assumes these are available on the system path for other OS's
         handbrake_path = "HandBrakeCLI"
         ffmpeg_path = "ffmpeg"
         be_path = "bulk_extractor"
+
+        # we will only be using Brunnhilde on non-Windows OS's
+        print("\n\n")
+        print("Brunnhilde is used to generate file format and checksum information for transfers")
+        brunnhilde_dir_input = input("Enter the directory where Brunnhilde reports will be saved: ")
+        brunnhilde_dir = _normalize_input(brunnhilde_dir_input)
 
     print("\n\n")
     print("The HandBrake CLI requires a preset file to generate derivatives")
@@ -92,6 +100,7 @@ def _create_config(config, config_file):
     config.set("defaults", "handbrake_preset", handbrake_preset)
     config.set("defaults", "ffmpeg", ffmpeg_path)
     config.set("defaults", "bulk_extractor", be_path)
+    config.set("defaults", "brunnhilde", brunnhilde_dir)
     _save_config(config, config_file)
 
 

--- a/bhl_born_digital_utils/run_brunnhilde.py
+++ b/bhl_born_digital_utils/run_brunnhilde.py
@@ -1,0 +1,17 @@
+import subprocess
+import sys
+
+from bhl_born_digital_utils.config import get_config_setting
+
+
+def run_brunnhilde(src, accession_number):
+    if "win" in sys.platform():
+        print("run_brunnhilde cannot be run on Windows")
+    else:
+        brunnhilde_dir = get_config_setting("brunnhilde")
+        cmd = [
+            "brunnhilde.py", "-nz",
+            src, brunnhilde_dir, accession_number
+        ]
+
+        subprocess.call(cmd)

--- a/bhl_born_digital_utils/run_brunnhilde.py
+++ b/bhl_born_digital_utils/run_brunnhilde.py
@@ -5,7 +5,7 @@ from bhl_born_digital_utils.config import get_config_setting
 
 
 def run_brunnhilde(src, accession_number):
-    if "win" in sys.platform():
+    if "win" in sys.platform:
         print("run_brunnhilde cannot be run on Windows")
     else:
         brunnhilde_dir = get_config_setting("brunnhilde")

--- a/bhl_born_digital_utils/run_brunnhilde.py
+++ b/bhl_born_digital_utils/run_brunnhilde.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import subprocess
 import sys
 
@@ -15,3 +17,11 @@ def run_brunnhilde(src, accession_number):
         ]
 
         subprocess.call(cmd)
+
+        transfer_metadata_dir = os.path.join(src, "metadata", "submissionDocumentation")
+        if not os.path.exists(transfer_metadata_dir):
+            os.makedirs(transfer_metadata_dir)
+
+        brunnhilde_reports = os.path.join(brunnhilde_dir, accession_number)
+        dst_dir = os.path.join(transfer_metadata_dir, "brunnhilde")
+        shutil.copytree(brunnhilde_reports, dst_dir)


### PR DESCRIPTION
This PR adds a `--brunnhilde` utility that will run [Brunnhilde](https://github.com/tw4l/brunnhilde) on a given transfer and copy the reports to a `metadata/submissionDocumentation` directory within the transfer root directory.