### PR TITLE
generate logs from various utils and include them in transfer

### DIFF
--- a/bhl_born_digital_utils/check_os_files.py
+++ b/bhl_born_digital_utils/check_os_files.py
@@ -56,20 +56,33 @@ def confirm_deletion(src_path, target_list, target_names, target_type):
 
     confirmation = input("\nDo you want to delete all of the above {}? ".format(target_type))
     if confirmation.lower().strip() in ["y", "yes"]:
-        delete_targets(target_list, target_type)
+        delete_targets(src_path, target_list, target_type)
 
 
-def delete_targets(target_list, target_type):
+def log_deletion(src_path, deleted_targets, target_type):
+    metadata_dir = os.path.join(src_path, "metadata", "submissionDocumentation")
+    if not os.path.exists(metadata_dir):
+        os.makedirs(metadata_dir)
+    logs_file = os.path.join(metadata_dir, "deleted_system_{}.txt".format(target_type))
+    with open(logs_file, "w") as f:
+        f.write("\n".join(deleted_targets))
+
+
+def delete_targets(src_path, target_list, target_type):
+    deleted_targets = []
     for target in target_list:
         if target_type == "files":
             try:
                 call(["attrib", "-H", "-R", "-S", target], stderr=DEVNULL, stdout=DEVNULL)
                 os.remove(target)
+                deleted_targets.append(target)
             except OSError:
                 print("Failed to delete file: {}".format(target))
         elif target_type == "directories":
             try:
                 shutil.rmtree(target)
+                deleted_targets.append(target)
             except OSError:
                 print("Failed to delete directory: {}".format(target))
     print("Deleted {}".format(target_type))
+    log_deletion(src_path, deleted_targets, target_type)

--- a/bhl_born_digital_utils/runbe.py
+++ b/bhl_born_digital_utils/runbe.py
@@ -52,7 +52,7 @@ def get_targets(src):
     return targets
 
 
-def parse_results(be_logs_dir):
+def parse_results(src, be_logs_dir):
     for barcode in os.listdir(be_logs_dir):
         barcode_path = os.path.join(be_logs_dir, barcode)
         for filename in os.listdir(barcode_path):
@@ -67,10 +67,13 @@ def parse_results(be_logs_dir):
         print("No bulk_extractor results found.")
         shutil.rmtree(be_logs_dir)
     else:
+        metadata_dir = os.path.join(src, "metadata", "submissionDocumentation")
+        dst_dir = os.path.join(metadata_dir, "bulk_extractor")
+        shutil.copytree(be_logs_dir, dst_dir)
         print("bulk_extractor results found for the following items:")
         for barcode in os.listdir(be_logs_dir):
             print(barcode)
-        print("Check the results for each item in {}".format(be_logs_dir))
+        print("Check the results for each item in {}".format(dst_dir))
 
 
 def run_bulk_extractor(src, logs_dir):
@@ -89,4 +92,4 @@ def run_bulk_extractor(src, logs_dir):
         output = os.path.join(be_logs_dir, target)
         command = get_bulk_extractor_command(source, output)
         subprocess.call(command)
-    parse_results(be_logs_dir)
+    parse_results(src, be_logs_dir)


### PR DESCRIPTION
This PR does the following:

- Generate a `renamed_files_and_directories.csv` when the `--rename` utility is run, consisting of original filepaths and renamed filepaths.
- Generate a `deleted_system_files.txt` and `deleted_system_directories.txt` when the `--osfiles` utility is run consisting of delete files and directories, respectively.
- Copy the output of the `--bulkextractor` to the transfer directory

All of the above are stored in a `metadata/submissionDocumentation` directory relative to the transfer's root directory.

Resolves #34 